### PR TITLE
add to_h and to_json to model

### DIFF
--- a/lib/corm/model.rb
+++ b/lib/corm/model.rb
@@ -103,6 +103,20 @@ module Corm
       nil
     end
 
+    def to_h
+      Hash[fields.keys.collect {|k| [k, self.send(k.to_sym)]}]
+    end
+
+    def to_json
+      res = self.to_h
+      fields.each do |k, t|
+        if t.start_with?("set")
+          res[k] = res[k].to_a
+        end
+      end
+      MultiJson.encode(res)
+    end
+
     def self.fields
       class_variable_set :@@fields, {} unless class_variable_defined? :@@fields
       class_variable_get :@@fields

--- a/lib/corm/model.rb
+++ b/lib/corm/model.rb
@@ -84,7 +84,13 @@ module Corm
         elsif type.start_with?('map')
           value.nil? ? {} : value
         elsif type == ('timestamp')
-          value.is_a?(Fixnum) ? Time.at(value) : value
+          if value.is_a?(Fixnum)
+            Time.at(value)
+          elsif value.is_a?(String)
+            Time.parse(value)
+          else
+            value
+          end
         else
           value
         end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -193,9 +193,8 @@ class TestModel < Test::Unit::TestCase
 
   def test_to_h
     model = FakeModel.new @data
-    expected = Hash[@data.keys.collect{|k| [k.to_s, @data[k]]}]
-    expected["set_text_field"] = expected["set_text_field"].to_set
-    assert_equal expected, model.to_h
+    @data[:set_text_field] = @data[:set_text_field].to_set
+    assert_equal @data, model.to_h
   end
 
   def test_to_json
@@ -212,5 +211,17 @@ class TestModel < Test::Unit::TestCase
     assert_equal(@data[:set_field], new_model.set_field)
     assert_equal(@data[:set_text_field].to_set, new_model.set_text_field)
     assert_equal(@data[:map_text_field], new_model.map_text_field)
+  end
+
+  def test_each
+    model = FakeModel.new @data
+    @data[:set_text_field] = @data[:set_text_field].to_set
+    assert(model.is_a?(Enumerable))
+    assert(model.each.is_a?(Enumerator))
+    model.each do |k, v|
+      assert_equal(v, @data[k.to_sym])
+    end
+
+    assert_equal(model.map{|k, v| k}, @data.map{|k, v| k})
   end
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -145,6 +145,18 @@ class TestModel < Test::Unit::TestCase
     assert_equal model2.timestamp_field.to_i, ts
   end
 
+  def test_timestamp_as_string
+    now = Time.now
+    ts = now.to_s
+    model = FakeModel.new({timestamp_field: ts, uuid_field: 'myuuid'})
+    assert model.timestamp_field.is_a?(Time), "timestamp_field should be a Time, is a #{model.timestamp_field.class}"
+    model.save
+
+    model2 = FakeModel.get uuid_field: model.uuid_field
+    assert model2
+    assert_equal model2.timestamp_field.to_s, ts
+  end
+
   def test_if_not_exists
     assert_raises Cassandra::Errors::AlreadyExistsError do
       FakeModel.keyspace!

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -191,4 +191,26 @@ class TestModel < Test::Unit::TestCase
     assert_equal 2, FakeModel.count
   end
 
+  def test_to_h
+    model = FakeModel.new @data
+    expected = Hash[@data.keys.collect{|k| [k.to_s, @data[k]]}]
+    expected["set_text_field"] = expected["set_text_field"].to_set
+    assert_equal expected, model.to_h
+  end
+
+  def test_to_json
+    model = FakeModel.new @data
+
+    new_model = FakeModel.new(MultiJson.decode(model.to_json))
+    assert_equal(@data[:uuid_field], new_model.uuid_field)
+    assert_equal(@data[:text_field], new_model.text_field)
+    assert_equal(@data[:int_field], new_model.int_field)
+    assert_equal(@data[:double_field], new_model.double_field)
+    assert_equal(@data[:boolean_field], new_model.boolean_field)
+    assert_equal(@data[:timestamp_field].to_i, new_model.timestamp_field.to_i)
+    assert_equal(@data[:list_field], new_model.list_field)
+    assert_equal(@data[:set_field], new_model.set_field)
+    assert_equal(@data[:set_text_field].to_set, new_model.set_text_field)
+    assert_equal(@data[:map_text_field], new_model.map_text_field)
+  end
 end


### PR DESCRIPTION
@stefanofontanelli helpers to convert the corm model to an hash and to a json.
It handles sets and timestamps etc.

Adds support for timestamps as strings as well (useful when unmarshalling from json, see tests)
